### PR TITLE
feat(export): add activity description fetch/export with rate-limit retry

### DIFF
--- a/src/helper_activities_caching.py
+++ b/src/helper_activities_caching.py
@@ -9,7 +9,7 @@ import pandas as pd
 import streamlit as st
 
 from helper import get_env
-from helper_api import fetch_all_activities, fetch_gear_data
+from helper_api import DIR_CACHE, fetch_all_activities, fetch_gear_data
 from helper_logging import get_logger_from_filename, track_function_usage
 from helper_pandas import reorder_cols
 
@@ -131,6 +131,35 @@ def cache_all_activities_and_gears() -> tuple[pd.DataFrame, pd.DataFrame]:
             st.stop()
         df_gear = pd.concat(dfs_gear)
     return df, df_gear
+
+
+@track_function_usage
+def refresh_activities_cache() -> None:
+    """
+    Clear cached activity lists so the next load re-fetches from Strava.
+
+    Gear and per-activity description caches are kept intact (descriptions are
+    expensive to re-fetch due to API rate limits).
+    """
+    cache_all_activities_and_gears_in_year_range.clear()
+    # in DEV the activity-list pages are also cached to disk, remove them too
+    if get_env() == "DEV":
+        for p in DIR_CACHE.glob("activities-page-*.json"):
+            p.unlink()
+
+
+@track_function_usage
+def clear_all_caches() -> None:
+    """
+    Clear all in-memory and on-disk caches, including activity descriptions.
+
+    Intended for local dev to force a full re-fetch from Strava.
+    """
+    st.cache_data.clear()
+    st.cache_resource.clear()
+    if get_env() == "DEV":
+        for p in DIR_CACHE.glob("*.json"):
+            p.unlink()
 
 
 # this cache is for 2h, while all others are only for 15min

--- a/src/helper_api.py
+++ b/src/helper_api.py
@@ -14,10 +14,15 @@ _LOGGER = get_logger_from_filename(__file__)
 
 
 API_RETRIES = 5
+HTTP_TOO_MANY_REQUESTS = 429
 URL_OAUTH = "https://www.strava.com/api/v3/oauth/token"
 URL_BASE = "https://www.strava.com/api/v3"
 # only used for local development to prevent api calls
 DIR_CACHE = Path("./cache/")
+
+
+class StravaRateLimitError(Exception):
+    """Raised when the Strava API rate limit (HTTP 429) is hit."""
 
 
 @track_function_usage
@@ -84,7 +89,11 @@ def _api_get(path: str) -> dict | list:
             # Raise HTTPError if HTTP request returns an unsuccessful status code
             resp.raise_for_status()
             return resp.json()
-        except requests.RequestException:
+        except requests.RequestException as e:
+            # do not retry on rate limit (HTTP 429), retrying only makes it worse
+            resp = getattr(e, "response", None)
+            if resp is not None and resp.status_code == HTTP_TOO_MANY_REQUESTS:
+                raise StravaRateLimitError from e
             _LOGGER.exception("Attempt %i failed", attempt)
             # If it's the last attempt, raise the exception
             if attempt + 1 == API_RETRIES:
@@ -289,3 +298,25 @@ def fetch_gear_data(gear_id: int, user_id: int) -> dict:
             write_cache_file(cache_file, d=d)
     assert isinstance(d, dict)
     return d
+
+
+@st.cache_data(ttl="60m")
+@track_function_usage
+def fetch_activity_description(activity_id: int, user_id: int) -> str:
+    """
+    Fetch detailed activity data and return its description.
+
+    One API call per activity, so use sparingly.
+    user_id is only included to double-ensure the caching is per user.
+    """
+    _ = user_id  # not used
+    cache_file = f"activity-{activity_id}.json"
+    d = None
+    if get_env() == "DEV":
+        d = read_cache_file(cache_file)
+    if not d:
+        d = _api_get(path=f"activities/{activity_id}")
+        if get_env() == "DEV":
+            write_cache_file(cache_file, d=d)
+    assert isinstance(d, dict)
+    return d.get("description") or ""

--- a/src/helper_ui_components.py
+++ b/src/helper_ui_components.py
@@ -79,3 +79,30 @@ def select_sport(
     return location.selectbox(
         label="Sport", options=options, key="sel_type", index=index
     )
+
+
+# how many years of activities to load, mapped to st.session_state["years"]
+_YEARS_OPTIONS = ["Current", "Last", "Last 5", "Last 10", "All"]
+_YEARS_LABEL_TO_VALUE = {
+    "Current": 0,
+    "Last": 1,
+    "Last 5": 5,
+    "Last 10": 10,
+    "All": 100,
+}
+_YEARS_VALUE_TO_INDEX = {0: 0, 1: 1, 5: 2, 10: 3}
+
+
+@track_function_usage
+def select_years(location: DeltaGenerator) -> None:
+    """
+    Display a selectbox to choose how many years of activities to load.
+
+    Stores the selection in st.session_state["years"], which is read by
+    cache_all_activities_and_gears().
+    """
+    if "years" not in st.session_state:
+        st.session_state["years"] = 0
+    index = _YEARS_VALUE_TO_INDEX.get(st.session_state["years"], 4)
+    sel = location.selectbox(label="Years", options=_YEARS_OPTIONS, index=index)
+    st.session_state["years"] = _YEARS_LABEL_TO_VALUE[sel]

--- a/src/reports/r01_load_data.py
+++ b/src/reports/r01_load_data.py
@@ -6,40 +6,14 @@ from helper_activities_caching import (
     cache_all_activities_and_gears,
 )
 from helper_logging import get_logger_from_filename
+from helper_ui_components import select_years
 
 _LOGGER = get_logger_from_filename(__file__)
 
 
 def main() -> None:  # noqa: D103
     col1, _ = st.columns((1, 5))
-    if "years" not in st.session_state:
-        st.session_state["years"] = 0
-    years = st.session_state["years"]
-
-    lst = ["Current", "Last", "Last 5", "Last 10", "All"]
-    if years == 0:
-        index = 0
-    elif years == 1:
-        index = 1
-    elif years == 5:  # noqa: PLR2004
-        index = 2
-    elif years == 10:  # noqa: PLR2004
-        index = 3
-    else:
-        index = 4
-
-    sel_years = col1.selectbox(label="Years", options=lst, index=index)
-
-    if sel_years == "Current":
-        st.session_state["years"] = 0
-    elif sel_years == "Last":
-        st.session_state["years"] = 1
-    elif sel_years == "Last 5":
-        st.session_state["years"] = 5
-    elif sel_years == "Last 10":
-        st.session_state["years"] = 10
-    else:
-        st.session_state["years"] = 100
+    select_years(col1)
 
     with st.spinner(text="Fetching your activities", show_time=True):
         df = cache_all_activities_and_gears()[0]

--- a/src/reports/r10_activity_list_and_excel_export.py
+++ b/src/reports/r10_activity_list_and_excel_export.py
@@ -1,22 +1,127 @@
 """Activity List and Excel Export."""
 
+import datetime as dt
 from math import isnan
 
+import pandas as pd
 import streamlit as st
 
+from helper import get_env
 from helper_activities_caching import (
     cache_all_activities_and_gears,
+    clear_all_caches,
+    refresh_activities_cache,
 )
+from helper_api import StravaRateLimitError, fetch_activity_description
 from helper_logging import get_logger_from_filename
-from helper_ui_components import excel_download_buttons, select_sport
+from helper_ui_components import excel_download_buttons, select_sport, select_years
 
 _LOGGER = get_logger_from_filename(__file__)
+
+
+def next_rate_limit_reset(now: dt.datetime) -> dt.datetime:
+    """
+    Return the next time Strava's 15-min rate-limit window resets.
+
+    Strava's short-term limit resets at :00/:15/:30/:45; a few seconds of buffer
+    are added to account for clock skew.
+    """
+    base = now.replace(second=0, microsecond=0)
+    minutes_to_next = 15 - (now.minute % 15)
+    return base + dt.timedelta(minutes=minutes_to_next, seconds=5)
+
+
+@st.fragment(run_every="10s")
+def description_retry_status(ids: list[int]) -> None:
+    """Show fetch progress and a Retry button that re-enables after the cooldown."""
+    descriptions: dict[int, str] = st.session_state.get("descriptions", {})
+    total = len(ids)
+    fetched = sum(1 for i in ids if i in descriptions)
+    cooldown_until = st.session_state.get("desc_cooldown_until")
+    now = dt.datetime.now(tz=dt.UTC)
+    if cooldown_until is not None and now < cooldown_until:
+        mins, secs = divmod(int((cooldown_until - now).total_seconds()), 60)
+        st.warning(
+            f"Strava API rate limit reached: {fetched} of {total} descriptions "
+            f"fetched. Retry available in {mins:02d}:{secs:02d}."
+        )
+        st.button("Retry fetch", disabled=True)
+    else:
+        st.info(f"{fetched} of {total} descriptions fetched, some are still missing.")
+        if st.button("Retry fetch"):
+            st.rerun()
+
+
+def fetch_and_attach_descriptions(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Fetch missing activity descriptions and add them as the x_description column.
+
+    Already fetched descriptions persist in session_state, so they stay visible and
+    are not re-requested. On hitting the rate limit, fetching pauses until the next
+    Strava reset; the retry status/button is rendered by description_retry_status().
+    """
+    user_id = st.session_state["USER_ID"]
+    descriptions: dict[int, str] = st.session_state.setdefault("descriptions", {})
+    ids = [int(i) for i in df.index]
+    total = len(ids)
+
+    now = dt.datetime.now(tz=dt.UTC)
+    cooldown_until = st.session_state.get("desc_cooldown_until")
+    in_cooldown = cooldown_until is not None and now < cooldown_until
+
+    missing = [i for i in ids if i not in descriptions]
+    if missing and not in_cooldown:
+        rate_limited = False
+        progress = st.progress(0.0, text="Fetching activity descriptions ...")
+        for n, activity_id in enumerate(missing):
+            try:
+                descriptions[activity_id] = fetch_activity_description(
+                    activity_id=activity_id, user_id=user_id
+                )
+            except StravaRateLimitError:
+                rate_limited = True
+                st.session_state["desc_cooldown_until"] = next_rate_limit_reset(
+                    dt.datetime.now(tz=dt.UTC)
+                )
+                break
+            progress.progress((n + 1) / len(missing))
+        progress.empty()
+        if not rate_limited:
+            st.session_state.pop("desc_cooldown_until", None)
+
+    df = df.copy()
+    df["x_description"] = [descriptions.get(i, "") for i in ids]
+
+    fetched = sum(1 for i in ids if i in descriptions)
+    if fetched < total:
+        description_retry_status(ids)
+    else:
+        st.success(f"All {total} activity descriptions fetched.")
+    return df
 
 
 def main() -> None:  # noqa: C901, D103, PLR0912, PLR0915
     st.markdown(
         "Edit at [Strava](https://www.strava.com/athlete/training) or bulk-edit using my [Äpp V1](https://entorb.net/strava-old/)"  # noqa: E501
     )
+
+    col_years, col_refresh, col_clear, _ = st.columns((1, 1, 1, 3))
+    select_years(col_years)
+    # vertical spacer so the button aligns with the selectbox input, not its label
+    col_refresh.markdown("<div style='height: 1.7em'></div>", unsafe_allow_html=True)
+    if col_refresh.button("Refresh", help="Re-fetch activities from Strava"):
+        refresh_activities_cache()
+        st.rerun()
+    if get_env() == "DEV":
+        col_clear.markdown(
+            "<div style='height: 1.7em'></div>", unsafe_allow_html=True
+        )
+        if col_clear.button(
+            "Clear cache",
+            help="Local dev only: clear ALL caches incl. activity descriptions",
+        ):
+            clear_all_caches()
+            st.rerun()
 
     df, df_gear = cache_all_activities_and_gears()
 
@@ -91,6 +196,14 @@ def main() -> None:  # noqa: C901, D103, PLR0912, PLR0915
     col7.button("Reset", on_click=reset_filters)
 
     st.columns(1)
+
+    fetch_desc = st.checkbox(
+        "Fetch activity descriptions"
+        f" ({len(df)} activities, 1 Strava API call each, may be slow)",
+        value=False,
+    )
+    if fetch_desc:
+        df = fetch_and_attach_descriptions(df)
 
     # to rename "x_" prefix
     col_names = {}


### PR DESCRIPTION

- fetch per-activity descriptions and include them in the Excel export
- add Years selector and Refresh button to the export page
- add dev-only Clear cache button to force a full re-fetch
- stop retrying on Strava HTTP 429 and add a cooldown + Retry button